### PR TITLE
[FIX] Add 'sys_file_metadata.uid' in select fields

### DIFF
--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -278,14 +278,15 @@ class FileRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
             '
             SELECT
                 distinct sys_file.uid,
-                sys_file_metadata.folder_uid 
+                sys_file_metadata.folder_uid,
+                sys_file_metadata.uid as metadatauid
             FROM
                 sys_file_metadata
                 INNER JOIN sys_file ON sys_file_metadata.file=sys_file.uid
             WHERE
                 ' . $where . '
             ORDER BY
-                sys_file_metadata.uid DESC 
+                metadatauid DESC 
             ',
             []
         );


### PR DESCRIPTION
Add 'sys_file_metadata.uid' in select fields because it's mandatory when this data is used in order by.

If this field is not present, when you click on 'detail' or 'edit' on a file, you'll have this error : 

> (1/3) #1472064775 TYPO3\CMS\Extbase\Persistence\Generic\Storage\Exception\SqlErrorException
> Expression #1 of ORDER BY clause is not in SELECT list, references column 'isasunflower.sys_file_metadata.uid' which is not in SELECT list; this is incompatible with DISTINCT