### PR TITLE
[FIX] Set the right folder tree icons

### DIFF
--- a/Resources/Public/JavaScript/Explorer.js
+++ b/Resources/Public/JavaScript/Explorer.js
@@ -42,9 +42,9 @@
             if (tree.querySelector(".current")) {
                 parents(tree.querySelector(".current"), tree).forEach(function(item, i) {
                     item.classList.add("active");
-                    item.parentElement.querySelector("a[data-action=expand] i").classList.remove("fa-folder");
-                    item.parentElement.querySelector("a[data-action=expand] i").classList.add("fa-folder-open");
                 });
+                $(".tree ul.active li.active > a i").removeClass("fa-folder");
+                $(".tree ul.active li.active > a i").addClass("fa-folder-open");
             }
             loadEventListener();
         }


### PR DESCRIPTION
Correct management of folder icons in folder tree for folders opened and folder closed.

The first time you open the file manager, the root folder is shown as an open folder whereas it is closed so you think that there are no sub-folder.