### PR TITLE
Solved an issue in uploading images to a non public folder

### DIFF
--- a/Classes/EventListener/Core/Resource/AfterFileCopiedEventListener.php
+++ b/Classes/EventListener/Core/Resource/AfterFileCopiedEventListener.php
@@ -16,28 +16,30 @@ class AfterFileCopiedEventListener extends AbstractFileEventListener
             $targetFolder->getIdentifier()
         );
 
-        $this->connectionPool
-            ->getConnectionForTable('sys_file_metadata')
-            ->update(
-                'sys_file_metadata',
-                ['folder_uid' => $folderRecord['uid']],
-                ['file' => $file->getUid() ]
-            );
+        if (!empty($folderRecord['uid']) && $file !== null) {
+            $this->connectionPool
+                ->getConnectionForTable('sys_file_metadata')
+                ->update(
+                    'sys_file_metadata',
+                    ['folder_uid' => $folderRecord['uid']],
+                    ['file' => $file->getUid() ]
+                );
 
-        if ($this->isFileContentSearchEnabled()) {
-            $textExtractorRegistry = \TYPO3\CMS\Core\Resource\TextExtraction\TextExtractorRegistry::getInstance();
-            try {
-                $textExtractor = $textExtractorRegistry->getTextExtractor($file);
-                if (!is_null($textExtractor)) {
-                    $this->connectionPool
-                        ->getConnectionForTable('tx_ameosfilemanager_domain_model_filecontent')
-                        ->insert('tx_ameosfilemanager_domain_model_filecontent', [
-                            'file'    => $file->getUid(),
-                            'content' => $textExtractor->extractText($file),
-                        ]);
+            if ($this->isFileContentSearchEnabled()) {
+                $textExtractorRegistry = \TYPO3\CMS\Core\Resource\TextExtraction\TextExtractorRegistry::getInstance();
+                try {
+                    $textExtractor = $textExtractorRegistry->getTextExtractor($file);
+                    if (!is_null($textExtractor)) {
+                        $this->connectionPool
+                            ->getConnectionForTable('tx_ameosfilemanager_domain_model_filecontent')
+                            ->insert('tx_ameosfilemanager_domain_model_filecontent', [
+                                'file'    => $file->getUid(),
+                                'content' => $textExtractor->extractText($file),
+                            ]);
+                    }
+                } catch (\Exception $e) {
+                    //
                 }
-            } catch (\Exception $e) {
-                //
             }
         }
     }

--- a/Classes/EventListener/Core/Resource/AfterFileMovedEventListener.php
+++ b/Classes/EventListener/Core/Resource/AfterFileMovedEventListener.php
@@ -16,12 +16,14 @@ class AfterFileMovedEventListener extends AbstractFileEventListener
             $targetFolder->getIdentifier()
         );
 
-        $this->connectionPool
-            ->getConnectionForTable('sys_file_metadata')
-            ->update(
-                'sys_file_metadata',
-                ['folder_uid' => $folderRecord['uid']],
-                ['file' => $file->getUid()]
-            );
+        if (!empty($folderRecord['uid'])) {
+            $this->connectionPool
+                ->getConnectionForTable('sys_file_metadata')
+                ->update(
+                    'sys_file_metadata',
+                    ['folder_uid' => $folderRecord['uid']],
+                    ['file' => $file->getUid()]
+                );
+        }
     }
 }

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -10,7 +10,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Resource\Index\MetaDataRepository;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /*
  * This file is part of the TYPO3 CMS project.

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,7 +18,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company'   => 'Ameos',
     'author_email'     => 'typo3dev@ameos.com',
     'state'            => 'beta',
-    'version'          => '2.0.3',
+    'version'          => '2.0.4',
     'autoload'         => ['psr-4' => ['Ameos\\AmeosFilemanager\\' => 'Classes']],
     'constraints'      => [
         'depends' => [


### PR DESCRIPTION
The FileUtility::add no longer tries to update the metadata when the folder cannot be found.
We is an issue in some of our projects where a non public folder is used.